### PR TITLE
Integrating boost Unit Test Framework and adding first unit test for options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(
 find_package(Threads)
 find_package(fmt REQUIRED)
 find_package(unofficial-http-parser REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
+find_package(Boost REQUIRED COMPONENTS system filesystem program_options unit_test_framework)
 find_package(restinio REQUIRED)
 
 target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ set(SOURCE "src")
 set(INCLUDE "include")
 set(TEST "test")
 
-include_directories(${INCLUDE})
 add_executable(
   dockerized-restinio
 
@@ -34,15 +33,25 @@ find_package(unofficial-http-parser REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options unit_test_framework)
 find_package(restinio REQUIRED)
 
-include_directories (${Boost_INCLUDE_DIRS})
+include_directories (${INCLUDE} ${Boost_INCLUDE_DIRS})
+
+set(
+  LINK_TARGETS
+  ${CMAKE_THREAD_LIBS_INIT}
+  fmt::fmt
+  unofficial::http_parser::http_parser
+  ${Boost_LIBRARIES}
+  restinio::restinio
+)
 
 enable_testing()
 file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${TEST}/*.cpp)
 foreach(testSrc ${TEST_SRCS})
   get_filename_component(testName ${testSrc} NAME_WE)
-  add_executable(${testName} ${testSrc})
-  target_link_libraries(${testName} ${Boost_LIBRARIES})
+  add_executable(${testName} ${testSrc} ${SOURCE}/options.cpp)
+  target_link_libraries(${testName} ${LINK_TARGETS} )
   set_target_properties(${testName} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin)
+  set_property(TARGET ${testName} PROPERTY CXX_STANDARD 14)
   add_test(
     NAME ${testName} 
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin 
@@ -50,14 +59,5 @@ foreach(testSrc ${TEST_SRCS})
   )
 endforeach(testSrc)
 
-target_link_libraries(
-  dockerized-restinio
-  PRIVATE
-    ${CMAKE_THREAD_LIBS_INIT}
-    fmt::fmt
-    unofficial::http_parser::http_parser
-    ${Boost_LIBRARIES}
-    restinio::restinio
-)
-
+target_link_libraries(dockerized-restinio PRIVATE ${LINK_TARGETS})
 set_property(TARGET dockerized-restinio PROPERTY CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,9 @@ project(dockerized-restinio
   VERSION 0.1
 )
 
-set(SOURCE "src/")
-set(INCLUDE "include/")
+set(SOURCE "src")
+set(INCLUDE "include")
+set(TEST "test")
 
 include_directories(${INCLUDE})
 add_executable(
@@ -32,6 +33,22 @@ find_package(fmt REQUIRED)
 find_package(unofficial-http-parser REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options unit_test_framework)
 find_package(restinio REQUIRED)
+
+include_directories (${Boost_INCLUDE_DIRS})
+
+enable_testing()
+file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${TEST}/*.cpp)
+foreach(testSrc ${TEST_SRCS})
+  get_filename_component(testName ${testSrc} NAME_WE)
+  add_executable(${testName} ${testSrc})
+  target_link_libraries(${testName} ${Boost_LIBRARIES})
+  set_target_properties(${testName} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin)
+  add_test(
+    NAME ${testName} 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin 
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/testBin/${testName}
+  )
+endforeach(testSrc)
 
 target_link_libraries(
   dockerized-restinio

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ WORKDIR /dockerized-restinio
 RUN mkdir build \
     && cd build \
     && cmake .. -DCMAKE_TOOLCHAIN_FILE=/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux-musl \
-    && make
+    && make \
+    && make test
 
 ###
 ### Runtime stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN cd /tmp \
 
 COPY x64-linux-musl.cmake /tmp/vcpkg/triplets/
 
-RUN VCPKG_FORCE_SYSTEM_BINARIES=1 ./tmp/vcpkg/vcpkg install boost-asio boost-filesystem boost-program-options fmt restinio
+RUN VCPKG_FORCE_SYSTEM_BINARIES=1 ./tmp/vcpkg/vcpkg install boost-asio boost-filesystem boost-program-options boost-test fmt restinio
 
 COPY ./ /dockerized-restinio
 WORKDIR /dockerized-restinio

--- a/test/test_hello.cpp
+++ b/test/test_hello.cpp
@@ -1,7 +1,0 @@
-#define BOOST_TEST_MODULE "Hello"
-
-#include <boost/test/unit_test.hpp>
-
-BOOST_AUTO_TEST_CASE( hello_test_case ) {
-  BOOST_TEST(true);
-}

--- a/test/test_hello.cpp
+++ b/test/test_hello.cpp
@@ -1,0 +1,7 @@
+#define BOOST_TEST_MODULE "Hello"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( hello_test_case ) {
+  BOOST_TEST(true);
+}

--- a/test/test_options.cpp
+++ b/test/test_options.cpp
@@ -1,0 +1,20 @@
+/* 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ *
+ */
+
+#define BOOST_TEST_MODULE "TestOptions"
+
+#include "options.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace dockerized_restinio;
+
+BOOST_AUTO_TEST_CASE(test_default_options) {
+  Options options;
+
+  BOOST_CHECK_EQUAL(options.address(), "0.0.0.0");
+  BOOST_CHECK_EQUAL(options.port(), 8080);
+}


### PR DESCRIPTION
Sources used for integration:
* http://neyasystems.com/an-engineers-guide-to-unit-testing-cmake-and-boost-unit-tests/
* https://www.boost.org/doc/libs/1_66_0/libs/test/doc/html/boost_test/practical_usage_recommendations/tutorials/bt_and_tdd.html
* https://github.com/jsankey/boost.test-examples